### PR TITLE
Fix DeepSeek endpoint

### DIFF
--- a/itf-extension/service_worker.js
+++ b/itf-extension/service_worker.js
@@ -2,7 +2,7 @@
 // and provide an options page for the user to configure it.
 // For this version, we use a placeholder.
 const API_KEY = 'sk-842f3e5432b5406d98a37532788e4aea';
-const ENDPOINT = 'https://api.deepseek.com/chat/completions';
+const ENDPOINT = 'https://api.deepseek.com/v1/chat/completions';
 
 // Simple in-memory cache. A more robust solution could use chrome.storage.local.
 const cache = new Map(); // K: text, V: { timestamp, result }
@@ -53,7 +53,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 /**
- * Fetches translation from the Google Translate API.
+ * Fetches translation from the DeepSeek API.
  * @param {string} q The text to translate.
  * @returns {Promise<string>} The translated text.
  */


### PR DESCRIPTION
## Summary
- correct DeepSeek API endpoint and comment

## Testing
- `node --check itf-extension/service_worker.js`
- `node --check itf-extension/content_script.js`
- `node --check itf-extension/popup.js`
- `node --check itf-extension/utils/queue.js`
- `node --check itf-extension/utils/sentence.js`


------
https://chatgpt.com/codex/tasks/task_e_684e52aab9a8832784974432dd902e21